### PR TITLE
DP-1 Match History Displaying 'Unknown Lane' for Arena Game mode

### DIFF
--- a/src/components/MatchHistory.js
+++ b/src/components/MatchHistory.js
@@ -93,7 +93,7 @@ const MatchHistory = ({
 	};
 
 	const getLaneName = (teamPosition, queueId) => {
-		if (queueId === 450 || teamPosition === "Invalid") {
+		if (queueId === 450 || teamPosition === "") {
 			return null;
 		}
 


### PR DESCRIPTION
Fixed a bug where getLaneName was looking for a string that matches "Invalid" to return null instead of an empty string